### PR TITLE
RE-246 Fork keyfunc package and adapt to form3tech-oss/jwt-go fork

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go}]
+indent_style = tab
+indent_size = 8
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SOURCES = $(shell find . -type f -iname "*.go")
+
+.PHONY: all build vet fmt test run image clean private
+
+all: test
+
+vet:
+	go vet ./...
+
+fmt: private
+	go fmt ./...
+
+test: fmt vet
+	go test ./... -coverprofile cover.out
+
+clean:
+	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/MicahParks/keyfunc)](https://goreportcard.com/report/github.com/MicahParks/keyfunc) [![Go Reference](https://pkg.go.dev/badge/github.com/MicahParks/keyfunc.svg)](https://pkg.go.dev/github.com/MicahParks/keyfunc)
+[![Go Report Card](https://goreportcard.com/badge/github.com/uswitch/keyfunc)](https://goreportcard.com/report/github.com/uswitch/keyfunc) [![Go Reference](https://pkg.go.dev/badge/github.com/uswitch/keyfunc.svg)](https://pkg.go.dev/github.com/uswitch/keyfunc)
 
 # keyfunc
 
 The sole purpose of this package is to provide a
-[`jwt.KeyFunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc) for the
-[github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) package using a JSON Web Key Set (JWKS) for parsing
+[`jwt.KeyFunc`](https://pkg.go.dev/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible#Keyfunc) for the
+[github.com/form3tech-oss/jwt-go](https://github.com/form3tech-oss/jwt-go) package using a JSON Web Key Set (JWKS) for parsing
 JSON Web Tokens (JWTs).
 
 It's common for an identity provider, such as [Keycloak](https://www.keycloak.org/) to expose a JWKS via an HTTPS
 endpoint. This package has the ability to consume that JWKS and produce a
-[`jwt.KeyFunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc). It is important that a JWKS
+[`jwt.KeyFunc`](https://pkg.go.dev/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible#Keyfunc). It is important that a JWKS
 endpoint is using HTTPS to ensure the keys are from the correct trusted source.
 
-There are no dependencies other than [github.com/dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go) for this
+There are no dependencies other than [github.com/form3tech-oss/jwt-go](https://github.com/form3tech-oss/jwt-go) for this
 repository.
 
 ## Supported Algorithms
@@ -47,13 +47,13 @@ this Go package, please open an issue or pull request.
 Please also see the `examples` directory.
 
 ```go
-import "github.com/MicahParks/keyfunc"
+import "github.com/uswitch/keyfunc"
 ```
 
 ### Step 1: Acquire the JWKS URL (optional)
 
 A JWKS URL is not required, one can be created directly from JSON with the
-[`keyfunc.New`](https://pkg.go.dev/github.com/MicahParks/keyfunc#New) function.
+[`keyfunc.New`](https://pkg.go.dev/github.com/uswitch/keyfunc#New) function.
 
 ```go
 // Get the JWKS URL from an environment variable.
@@ -75,10 +75,10 @@ if err != nil {
 }
 ```
 
-Additional options can be passed to the [`keyfunc.Get`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Get) function
-via variadic arguments. See [`keyfunc.Options`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Options).
+Additional options can be passed to the [`keyfunc.Get`](https://pkg.go.dev/github.com/uswitch/keyfunc#Get) function
+via variadic arguments. See [`keyfunc.Options`](https://pkg.go.dev/github.com/uswitch/keyfunc#Options).
 
-### Step 3: Use the [`keyfunc.JWKS`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKS) 's [`JWKS.KeyFunc`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKS.KeyFunc) method as the [`jwt.KeyFunc`](https://pkg.go.dev/github.com/dgrijalva/jwt-go@v3.2.0+incompatible#Keyfunc) when parsing tokens
+### Step 3: Use the [`keyfunc.JWKS`](https://pkg.go.dev/github.com/uswitch/keyfunc#JWKS) 's [`JWKS.KeyFunc`](https://pkg.go.dev/github.com/uswitch/keyfunc#JWKS.KeyFunc) method as the [`jwt.KeyFunc`](https://pkg.go.dev/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible#Keyfunc) when parsing tokens
 
 ```go
 // Parse the JWT.
@@ -88,7 +88,7 @@ if err != nil {
 }
 ```
 
-The [`JWKS.KeyFunc`](https://pkg.go.dev/github.com/MicahParks/keyfunc#JWKS.KeyFunc) method will automatically select
+The [`JWKS.KeyFunc`](https://pkg.go.dev/github.com/uswitch/keyfunc#JWKS.KeyFunc) method will automatically select
 the key with the matching `kid` (if present) and return its public key as the correct Go type to its caller.
 
 ## Test coverage
@@ -103,16 +103,16 @@ does not introduce any dependencies is welcome though.
 ## Additional features
 
 * A background refresh of the JWKS keys can be performed. This is possible by passing
-  [`keyfunc.Options`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Options) via a variadic argument to the
-  [`keyfunc.Get`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Get) function.
+  [`keyfunc.Options`](https://pkg.go.dev/github.com/uswitch/keyfunc#Options) via a variadic argument to the
+  [`keyfunc.Get`](https://pkg.go.dev/github.com/uswitch/keyfunc#Get) function.
     * A custom background refresh interval can be specified.
     * A custom background refresh request context timeout can be specified. Defaults to one minute.
     * A custom background refresh error handling function can be specified. If none is specified, errors go unhandled
       silently.
 * JWTs with a previously unseen `kid` can prompt an automatic refresh of the remote JWKS resource.
 * A custom HTTP client can be used. This is possible by passing
-  [`keyfunc.Options`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Options) via a variadic argument to the
-  [`keyfunc.Get`](https://pkg.go.dev/github.com/MicahParks/keyfunc#Get) function.
+  [`keyfunc.Options`](https://pkg.go.dev/github.com/uswitch/keyfunc#Options) via a variadic argument to the
+  [`keyfunc.Get`](https://pkg.go.dev/github.com/uswitch/keyfunc#Get) function.
 
 ## TODO
 

--- a/examples/get/get.go
+++ b/examples/get/get.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/form3tech-oss/jwt-go"
 
-	"github.com/MicahParks/keyfunc"
+	"github.com/uswitch/keyfunc"
 )
 
 func main() {

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/form3tech-oss/jwt-go"
 
-	"github.com/MicahParks/keyfunc"
+	"github.com/uswitch/keyfunc"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/MicahParks/keyfunc
+module github.com/uswitch/keyfunc
 
 go 1.13
 
-require github.com/dgrijalva/jwt-go v3.2.0+incompatible
+require github.com/form3tech-oss/jwt-go v3.2.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/form3tech-oss/jwt-go"
 
-	"github.com/MicahParks/keyfunc"
+	"github.com/uswitch/keyfunc"
 )
 
 const (

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/form3tech-oss/jwt-go"
 )
 
 var (
@@ -16,7 +16,7 @@ var (
 	ErrUnsupportedKeyType = errors.New("the JWT key type is unsupported")
 )
 
-// KeyFunc is a compatibility function that matches the signature of github.com/dgrijalva/jwt-go's KeyFunc function.
+// KeyFunc is a compatibility function that matches the signature of github.com/form3tech-oss/jwt-go's KeyFunc function.
 func (j *JWKS) KeyFunc(token *jwt.Token) (interface{}, error) {
 
 	// Get the kid from the token header.
@@ -42,6 +42,6 @@ func (j *JWKS) KeyFunc(token *jwt.Token) (interface{}, error) {
 	case ps256, ps384, ps512, rs256, rs384, rs512:
 		return jsonKey.RSA()
 	default:
-		return nil, fmt.Errorf("%w: %s: feel free to add a feature request or contribute to https://github.com/MicahParks/keyfunc", ErrUnsupportedKeyType, keyAlg)
+		return nil, fmt.Errorf("%w: %s: feel free to add a feature request or contribute to https://github.com/uswitch/keyfunc", ErrUnsupportedKeyType, keyAlg)
 	}
 }


### PR DESCRIPTION
We'd like to use https://github.com/auth0/go-jwt-middleware as an OIDC middleware but have keys provided through JWKS.

This project is perfect for the latter but needs to be adapted to the forked lib that the auth0 middleware is using.